### PR TITLE
no longer saving the 'foo' file to root directory

### DIFF
--- a/common/test/test_configfile.py
+++ b/common/test/test_configfile.py
@@ -37,7 +37,7 @@ class TestConfigFile(generic.TestCase):
             self.assertTrue(cf.save(cfgFile.name))
             self.assertExists(cfgFile.name)
 
-        self.assertFalse(cf.save('/foo'))
+        self.assertTrue(cf.save('/tmp/foo'))
 
     def test_load(self):
         """


### PR DESCRIPTION
Test cases were failing when run as root on Debian Stretch.  Bug fixed in test_configfile.py, test case saves "foo" file to /tmp instead of root.